### PR TITLE
[#74]Feat: 일정이 없다는 View를 띄울 때 시간 차 문제 해결

### DIFF
--- a/JoinUs/Enum/LeagueScheduleTableViewSectionType.swift
+++ b/JoinUs/Enum/LeagueScheduleTableViewSectionType.swift
@@ -20,12 +20,12 @@ enum LeagueScheduleTableViewSectionType: String {
         }
     }
     
-    func image() -> Data {
+    func imageUrl() -> URL {
         switch self {
         case .worlds:
-            return try! Data(contentsOf: URL(string: "https://cdn.pandascore.co/images/league/image/297/220px-Worlds_2020.png")!)
+            return URL(string: "https://cdn.pandascore.co/images/league/image/297/220px-Worlds_2020.png")!
         case .lck:
-            return try! Data(contentsOf: URL(string: "https://cdn.pandascore.co/images/league/image/293/LCK_2021_logo.png")!)
+            return URL(string: "https://cdn.pandascore.co/images/league/image/293/LCK_2021_logo.png")!
         }
     }
 }

--- a/JoinUs/Source/Home/Cell/ScheduleTableViewCell.swift
+++ b/JoinUs/Source/Home/Cell/ScheduleTableViewCell.swift
@@ -22,6 +22,7 @@ final class ScheduleTableViewCell: UITableViewCell {
             bottom: 0,
             right: 10
         )
+        tableView.separatorStyle = .none
         
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = .zero
@@ -60,12 +61,20 @@ final class ScheduleTableViewCell: UITableViewCell {
             
         self.worldsTodayViewModel.scheduleList.bind { _ in
             DispatchQueue.main.async {
+                if self.worldsTodayViewModel.scheduleList.value!.count > 0 {
+                    self.leagueType = "worlds"
+                }
+                
                 self.leagueScheduleTableView.reloadData()
             }
         }
         
         self.lckTodayViewModel.scheduleList.bind { _ in
             DispatchQueue.main.async {
+                if self.lckTodayViewModel.scheduleList.value!.count > 0 {
+                    self.leagueType = "lck"
+                }
+                
                 self.leagueScheduleTableView.reloadData()
             }
         }
@@ -78,14 +87,6 @@ extension ScheduleTableViewCell: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if worldsTodayViewModel.scheduleList.value!.count > 0 {
-            leagueType = "worlds"
-        }
-
-        else if lckTodayViewModel.scheduleList.value!.count > 0 {
-            leagueType = "lck"
-        }
-        
         if let leagueType = leagueType {
             let leagueScheduleTableViewSectionType = LeagueScheduleTableViewSectionType(rawValue: leagueType)!
             
@@ -105,6 +106,7 @@ extension ScheduleTableViewCell: UITableViewDataSource {
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
         if let leagueType = leagueType {
+            leagueScheduleTableView.separatorStyle = .singleLine
             let leagueScheduleTableViewSectionType = LeagueScheduleTableViewSectionType(rawValue: leagueType)!
             
             switch leagueScheduleTableViewSectionType {
@@ -135,17 +137,22 @@ extension ScheduleTableViewCell: UITableViewDataSource {
         }
         
         else {
-//            guard let cell = tableView.dequeueReusableCell(
-//                withIdentifier: NoScheduleTableViewCell.identifier,
-//                for: indexPath
-//            ) as? NoScheduleTableViewCell else {
-//                return UITableViewCell()
-//            }
-//
-//            cell.configureCell()
-//
-//            return cell
-            return UITableViewCell()
+            if !worldsTodayViewModel.hasScheduleData && !lckTodayViewModel.hasScheduleData {
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: NoScheduleTableViewCell.identifier,
+                    for: indexPath
+                ) as? NoScheduleTableViewCell else {
+                    return UITableViewCell()
+                }
+                
+                cell.configureCell()
+                
+                return cell
+            }
+            
+            else {
+                return UITableViewCell()
+            }
         }
     }
     
@@ -159,13 +166,15 @@ extension ScheduleTableViewCell: UITableViewDataSource {
             switch leagueScheduleTableViewSectionType {
             case .worlds:
                 let worldsSectionHeader = LeagueScheduleTableViewSectionHeader()
-                worldsSectionHeader.configureUI(leagueScheduleTableViewSectionType: .worlds)
+                worldsSectionHeader.configureUI()
+                worldsSectionHeader.update(leagueScheduleTableViewSectionType: .worlds)
                 
                 return worldsSectionHeader
                 
             case .lck:
                 let lckSectionHeader = LeagueScheduleTableViewSectionHeader()
-                lckSectionHeader.configureUI(leagueScheduleTableViewSectionType: .lck)
+                lckSectionHeader.configureUI()
+                lckSectionHeader.update(leagueScheduleTableViewSectionType: .lck)
                 
                 return lckSectionHeader
             }
@@ -177,7 +186,7 @@ extension ScheduleTableViewCell: UITableViewDataSource {
 
 extension ScheduleTableViewCell: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if leagueType == nil {
+        if !worldsTodayViewModel.hasScheduleData && !lckTodayViewModel.hasScheduleData {
             return 150
         }
         

--- a/JoinUs/Source/Home/Controller/HomeViewController.swift
+++ b/JoinUs/Source/Home/Controller/HomeViewController.swift
@@ -162,12 +162,14 @@ extension HomeViewController: UITableViewDataSource {
         switch homeTableViewSectionType {
         case .schedule:
             let scheduleSectionHeader = HomeTableViewSectionHeader()
-            scheduleSectionHeader.configureUI(homeTableViewSectionType: .schedule)
+            scheduleSectionHeader.configureUI()
+            scheduleSectionHeader.update(homeTableViewSectionType: .schedule)
             
             return scheduleSectionHeader
         case .player:
             let playerSectionHeader = HomeTableViewSectionHeader()
-            playerSectionHeader.configureUI(homeTableViewSectionType: .player)
+            playerSectionHeader.configureUI()
+            playerSectionHeader.update(homeTableViewSectionType: .player)
             
             return playerSectionHeader
         }

--- a/JoinUs/Source/Home/View/HomeTableViewSectionHeader.swift
+++ b/JoinUs/Source/Home/View/HomeTableViewSectionHeader.swift
@@ -24,7 +24,7 @@ final class HomeTableViewSectionHeader: UIView {
         return label
     }()
     
-    func configureUI(homeTableViewSectionType: HomeTableViewSectionType) {
+    func configureUI() {
         backgroundColor = .systemGray6
         
         addSubview(TitleView)
@@ -44,7 +44,9 @@ final class HomeTableViewSectionHeader: UIView {
             TitleLabel.centerYAnchor.constraint(equalTo: TitleView.centerYAnchor),
             TitleLabel.heightAnchor.constraint(equalToConstant: 20)
         ])
-        
+    }
+    
+    func update(homeTableViewSectionType: HomeTableViewSectionType) {
         TitleLabel.text = homeTableViewSectionType.title()
     }
 }

--- a/JoinUs/Source/Home/View/LeagueScheduleTableViewSectionHeader.swift
+++ b/JoinUs/Source/Home/View/LeagueScheduleTableViewSectionHeader.swift
@@ -5,6 +5,7 @@
 //  Created by SeungMin on 2021/11/08.
 //
 
+import Kingfisher
 import UIKit
 
 final class LeagueScheduleTableViewSectionHeader: UIView {
@@ -36,7 +37,7 @@ final class LeagueScheduleTableViewSectionHeader: UIView {
         return label
     }()
     
-    func configureUI(leagueScheduleTableViewSectionType: LeagueScheduleTableViewSectionType) {
+    func configureUI() {
         backgroundColor = .systemGray6
         
         addSubview(leagueView)
@@ -70,8 +71,37 @@ final class LeagueScheduleTableViewSectionHeader: UIView {
             leagueTitleLabel.bottomAnchor.constraint(equalTo: leagueDataView.bottomAnchor),
             leagueTitleLabel.widthAnchor.constraint(equalToConstant: 100),
         ])
-        
-        leagueImageView.image = UIImage(data: leagueScheduleTableViewSectionType.image())
+    }
+    
+    func update(leagueScheduleTableViewSectionType: LeagueScheduleTableViewSectionType) {
+        setLeagueImage(
+            leagueImageUrl: leagueScheduleTableViewSectionType.imageUrl(),
+            leagueImageView: leagueImageView
+        )
         leagueTitleLabel.text = leagueScheduleTableViewSectionType.title()
+    }
+    
+    func setLeagueImage(leagueImageUrl: URL, leagueImageView: UIImageView) {
+        let processor = DownsamplingImageProcessor(size: CGSize(width: 20, height: 20))
+        leagueImageView.kf.indicatorType = .activity
+        leagueImageView.kf.setImage(
+            with: leagueImageUrl,
+            placeholder: UIImage(named: "placeholderImage"),
+            options: [
+                .processor(processor),
+                .scaleFactor(UIScreen.main.scale),
+                .transition(.fade(1)),
+                .cacheOriginalImage
+            ]
+        )
+        {
+            result in
+            switch result {
+            case .success(let value):
+                print("Task done for: \(value.source.url?.absoluteString ?? "")")
+            case .failure(let error):
+                print("Job failed: \(error.localizedDescription)")
+            }
+        }
     }
 }

--- a/JoinUs/Source/Home/ViewModel/LeagueScheduleTableViewModel.swift
+++ b/JoinUs/Source/Home/ViewModel/LeagueScheduleTableViewModel.swift
@@ -11,6 +11,7 @@ final class LeagueScheduleTableViewModel {
     private let dateFormatter = DateFormatter()
     var scheduleList: Observable<[LeagueScheduleTableViewCellModel]> = Observable([])
     var leagueType: RequestLeagueType
+    var hasScheduleData: Bool = true
     
     var countScheduleList: Int {
         return scheduleList.value?.count ?? 0
@@ -25,11 +26,13 @@ final class LeagueScheduleTableViewModel {
     }
     
     func fetchData() {
-        DispatchQueue.main.async {
-            NetworkManger().getScheduleData(leagueType: self.leagueType) { receivedScheduleModel in
-                self.scheduleList.value = receivedScheduleModel.compactMap({ schedule in
-                    self.extractScehduleData(schedule: schedule)
-                })
+        NetworkManger().getScheduleData(leagueType: self.leagueType) { receivedScheduleModel in
+            self.scheduleList.value = receivedScheduleModel.compactMap({ schedule in
+                self.extractScehduleData(schedule: schedule)
+            })
+            
+            if self.scheduleList.value!.count == 0 {
+                self.hasScheduleData = false
             }
         }
     }


### PR DESCRIPTION
- LeagueScheduleTableViewModel
hasScheduleData 프로퍼티 생성
observable type의 리그 일정데이터가 있으면 true 업으면 false
default는 true -> 모든 일정이 없을 경우 띄울 뷰 구현을 위함

- ScheduleTableViewCell
현재 데이터가 있는 리그를 저장하는 leagueType 구현
worlds, lck 일정 모두 없을 때만 noScheduleTableViewCell 띄우기
leagueScheduleTableView의 셀 간 구분선을 .none으로 설정
일정이 있을 때만 셀 간 구분선을 적용

- HomeTableViewSectionHeader
cell의 특정 뷰에 값을 할당할 수 있는 update 함수 구현

- LeagueScheduleTableViewSectionHeader
update 함수 구현
Kingfisher를 이용해서 리그 이미지를 가져오는 setLeagueImage() 함수 구현

- HomeViewController
섹션의 update함수 적용

- LeagueScheduleTableViewSectionType
Data -> URL